### PR TITLE
Update root endpoint test docstring

### DIFF
--- a/tests/unit/api/test_main.py
+++ b/tests/unit/api/test_main.py
@@ -43,7 +43,7 @@ class TestAPIEndpoints:
 
         Given: The API server
         When: A GET request is made to "/"
-        Then: It should return a 200 status code and a status of "ok".
+        Then: It should return a 200 status code and a status of "✅ API is up and running".
         """
         # Execute
         response = test_client.get("/")


### PR DESCRIPTION
## Summary
- fix the description in `test_root_endpoint` to match the actual status text

## Testing
- `pytest tests/unit/api/test_main.py::TestAPIEndpoints::test_root_endpoint -q` *(fails: ModuleNotFoundError: No module named 'jinja2')*

------
https://chatgpt.com/codex/tasks/task_e_6841d365f0f0832d99de6c9dcf9a9d6c